### PR TITLE
[WIP] feat: add default value and multi-key get implementations.

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,11 +1,10 @@
-
 #### Checklist for Integrity
 <!-- Please remove any items that do not apply. For completed items, change [] to [x]. -->
 
-- [] `npm run quick` passes without issues. This will be automatically executing with a Matrix on GitHub Workflow.
-- [] Tests have been updated or added to reflect your changes, if you modified existing adapters or added new adapters.
-- [] Documentation on all classes, functions, and properties have been included in added or modified source code.
-- [] All commit message(es) follow the syntax of [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0-beta.2/#summary).
+- [ ] `npm run project:build` passes without issues. This will be automatically executed with a Matrix on GitHub Workflow.
+- [ ] Tests have been updated or added to reflect your changes if you modified existing adapters or added new adapters.
+- [ ] Documentation on all classes, functions, and properties have been included in added or modified source code.
+- [ ] All commit message(es) follow the syntax of [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0-beta.2/#summary).
 
 #### Affected Core Services
 <!-- Please specify any specific areas that may affected by these changes. -->

--- a/.gitignore
+++ b/.gitignore
@@ -234,3 +234,4 @@ modules.xml
 # .pnp.*
 
 # End of https://www.toptal.com/developers/gitignore/api/node,yarn,webstorm+all,visualstudiocode,vscode
+/tests/ci.database

--- a/custom.gitignore
+++ b/custom.gitignore
@@ -1,0 +1,1 @@
+/tests/ci.database

--- a/lib/adapters/generic.ts
+++ b/lib/adapters/generic.ts
@@ -55,9 +55,20 @@ export abstract class GenericAdapter extends MapAPI {
    *
    * @param key - The key to be validated.
    */
-  _isKeyAcceptable (key: string): void {
-    if (typeof key !== 'string') throw new Error('InvalidState: key must be a valid string')
-    if (key.length === 0 || key.trim() === '') throw new Error('InvalidState: key must be greater than 0 and less than 192 characters')
+  _isKeyAcceptable (key: string | string[]): void {
+    if (Array.isArray(key)) {
+      // The input was an array of keys. Validate each entry.
+      if (key.length === 0) throw new Error('InvalidState: key array must contain at least 1 entry')
+      for (let i = 0; i < key.length; i++) {
+        const k = key[i]
+        if (typeof k !== 'string') throw new Error(`InvalidState[index:${i}]: key must be a valid string`)
+        if (k.length === 0 || k.trim() === '') throw new Error('InvalidState: key must be greater than 0 and less than 192 characters')
+      }
+    } else {
+      // The input was singular. Verify the input.
+      if (typeof key !== 'string') throw new Error('InvalidState: key must be a valid string')
+      if (key.length === 0 || key.trim() === '') throw new Error('InvalidState: key must be greater than 0 and less than 192 characters')
+    }
   }
 
   /**

--- a/lib/adapters/generic.ts
+++ b/lib/adapters/generic.ts
@@ -22,6 +22,7 @@ export abstract class GenericAdapter extends MapAPI {
    */
   _serialize (state: InternalMapper): string {
     if (state.encoder?.use) {
+      // Convert JS to Serialized, Stringify JSON
       state.ctx = { save: Buffer.from(JSON.stringify(toJSON(state.ctx))).toString(state.encoder.store) }
     }
 
@@ -42,10 +43,21 @@ export abstract class GenericAdapter extends MapAPI {
     const response = fromJSON(JSON.parse(state.value)) as InternalMapper
 
     if (response.encoder?.use) {
+      // Parse JSON, Convert Serialized to JS
       response.ctx = fromJSON(JSON.parse(Buffer.from(response.ctx.save, response.encoder.store).toString(response.encoder.parse)))
     }
 
     return response
+  }
+
+  /**
+   * Validate the user input key.
+   *
+   * @param key - The key to be validated.
+   */
+  _isKeyAcceptable (key: string): void {
+    if (typeof key !== 'string') throw new Error('InvalidState: key must be a valid string')
+    if (key.length === 0 || key.trim() === '') throw new Error('InvalidState: key must be greater than 0 and less than 192 characters')
   }
 
   /**
@@ -74,15 +86,5 @@ export abstract class GenericAdapter extends MapAPI {
       return true
     }
     return false
-  }
-
-  /**
-   * Validate the user input key.
-   *
-   * @param key - The key to be validated.
-   */
-  _isKeyAcceptable (key: string): void {
-    if (typeof key !== 'string') throw new Error('InvalidState: key must be a valid string')
-    if (key.length === 0 || key.trim() === '') throw new Error('InvalidState: key must be greater than 0 and less than 192 characters')
   }
 }

--- a/lib/adapters/memory.ts
+++ b/lib/adapters/memory.ts
@@ -1,6 +1,6 @@
 import { DateTime, Duration } from 'luxon'
 
-import { InternalMapper, MapperOptions } from '../types/generics.t'
+import { InternalMapper, MapperOptions, GetOptions } from '../types/generics.t'
 import { GenericAdapter } from './generic'
 
 export class MemoryAdapter extends GenericAdapter {
@@ -36,18 +36,19 @@ export class MemoryAdapter extends GenericAdapter {
    * Retrieves the value assigned to the supplied key from the referenced storage driver.
    *
    * @param key - The referenced key to obtain from the storage driver.
+   * @param options - [optional] Specify the default value for the response, at this time.
    *
    * @returns - The value assigned to the key.
    */
-  async get (key: string): Promise<any> {
+  async get (key: string, options: GetOptions): Promise<any> {
     super._isKeyAcceptable(key)
 
     const value = await this.map.get(key)
-    if (value === undefined || value.ctx === undefined) return undefined
+    if (value === undefined || value.ctx === undefined) return options?.default
 
     if (super._isMapperExpired(value)) {
       await this.delete(key)
-      return undefined
+      return options?.default
     }
 
     return value?.ctx

--- a/lib/adapters/sqlite.ts
+++ b/lib/adapters/sqlite.ts
@@ -2,7 +2,7 @@ import { DateTime, Duration } from 'luxon'
 import { TableWithColumns } from 'sql-ts'
 
 import { IValueTable, SQLBuilder } from '../builder/sql'
-import { MapperOptions } from '../types/generics.t'
+import { GetOptions, MapperOptions } from '../types/generics.t'
 import { SQLite3Options } from '../types/sqlite.t'
 import { GenericAdapter } from './generic'
 
@@ -102,22 +102,23 @@ export class SQLiteAdapter extends GenericAdapter {
    * Retrieves the value assigned to the supplied key from the referenced storage driver.
    *
    * @param key - The referenced key to obtain from the storage driver.
+   * @param options - [optional] Specify the default value for the response, at this time.
    *
    * @returns - The value assigned to the key.
    */
-  async get (key: string): Promise<any> {
+  async get (key: string, options: GetOptions): Promise<any> {
     super._isKeyAcceptable(key)
 
-    const snapshot = await this.getOne(this.table.select().where({ key }).toString())
-    const parser = super._deserialize(snapshot)
-    if (parser === undefined) return parser
+    const state = await this.getOne(this.table.select().where({ key }).toString())
+    const deserialized = super._deserialize(state)
+    if (deserialized === undefined) return options?.default
 
-    if (super._isMapperExpired(parser)) {
+    if (super._isMapperExpired(deserialized)) {
       await this.delete(key)
-      return undefined
+      return options?.default
     }
 
-    return parser?.ctx
+    return deserialized?.ctx
   }
 
   /**

--- a/lib/adapters/sqlite.ts
+++ b/lib/adapters/sqlite.ts
@@ -109,16 +109,47 @@ export class SQLiteAdapter extends GenericAdapter {
   async get (key: string, options: GetOptions): Promise<any> {
     super._isKeyAcceptable(key)
 
-    const state = await this.getOne(this.table.select().where({ key }).toString())
-    const deserialized = super._deserialize(state)
-    if (deserialized === undefined) return options?.default
+    if (!Array.isArray(key)) {
+      const state = await this.getOne(this.table.select().where({ key }).toString())
+      const deserialized = super._deserialize(state)
+      if (deserialized === undefined) return options?.default
 
-    if (super._isMapperExpired(deserialized)) {
-      await this.delete(key)
-      return options?.default
+      if (super._isMapperExpired(deserialized)) {
+        await this.delete(key)
+        return options?.default
+      }
+
+      return deserialized?.ctx
+    } else {
+      const response = []
+
+      for (const k of key) {
+        const state = await this.getOne(this.table.select().where({ key: k }).toString())
+        const deserialized = super._deserialize(state)
+        if (deserialized === undefined) {
+          response.push({
+            key: k,
+            value: options?.default
+          })
+          continue
+        }
+        if (super._isMapperExpired(deserialized)) {
+          await this.delete(k)
+          response.push({
+            key: k,
+            value: options?.default
+          })
+          continue
+        }
+
+        response.push({
+          key: k,
+          value: deserialized?.ctx
+        })
+      }
+
+      return response
     }
-
-    return deserialized?.ctx
   }
 
   /**

--- a/lib/builder/map.ts
+++ b/lib/builder/map.ts
@@ -21,7 +21,7 @@ export abstract class MapAPI {
    *
    * @returns - The value associated with the key index. If no value exists, this will return null.
    */
-  abstract get (key: string, options: GetOptions): Promise<any | null>
+  abstract get (key: string | string[], options: GetOptions): Promise<any | any[] | undefined>
 
   /**
    * Checks the provided key for if its respective value exists on the configured Storage Backend Adapter.

--- a/lib/builder/map.ts
+++ b/lib/builder/map.ts
@@ -1,3 +1,4 @@
+import { GetOptions } from '../types/generics.t'
 export abstract class MapAPI {
   /**
    * Permanently removes all entries from the Storage Backend Adapter.
@@ -20,7 +21,7 @@ export abstract class MapAPI {
    *
    * @returns - The value associated with the key index. If no value exists, this will return null.
    */
-  abstract get (key: string): Promise<any | null>
+  abstract get (key: string, options: GetOptions): Promise<any | null>
 
   /**
    * Checks the provided key for if its respective value exists on the configured Storage Backend Adapter.

--- a/lib/types/generics.t.ts
+++ b/lib/types/generics.t.ts
@@ -1,5 +1,10 @@
 import { Encoding } from 'crypto'
 
+/** The representation of the Get Options */
+export interface GetOptions {
+  default: any
+}
+
 /** The representation of the Internal Mapping Instance */
 export interface InternalMapper {
   key: string

--- a/package-lock.json
+++ b/package-lock.json
@@ -156,9 +156,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "14.14.19",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.19.tgz",
-      "integrity": "sha512-4nhBPStMK04rruRVtVc6cDqhu7S9GZai0fpXgPXrFpcPX6Xul8xnrjSdGB4KPBVYG/R5+fXWdCM8qBoiULWGPQ==",
+      "version": "14.14.20",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.20.tgz",
+      "integrity": "sha512-Y93R97Ouif9JEOWPIUyU+eyIdyRqQR0I8Ez1dzku4hDx34NWh4HbtIc3WNzwB1Y9ULvNGeu5B8h8bVL5cAk4/A==",
       "dev": true
     },
     "@types/parse-json": {
@@ -168,13 +168,13 @@
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "4.11.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.11.1.tgz",
-      "integrity": "sha512-fABclAX2QIEDmTMk6Yd7Muv1CzFLwWM4505nETzRHpP3br6jfahD9UUJkhnJ/g2m7lwfz8IlswcwGGPGiq9exw==",
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.12.0.tgz",
+      "integrity": "sha512-wHKj6q8s70sO5i39H2g1gtpCXCvjVszzj6FFygneNFyIAxRvNSVz9GML7XpqrB9t7hNutXw+MHnLN/Ih6uyB8Q==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/experimental-utils": "4.11.1",
-        "@typescript-eslint/scope-manager": "4.11.1",
+        "@typescript-eslint/experimental-utils": "4.12.0",
+        "@typescript-eslint/scope-manager": "4.12.0",
         "debug": "^4.1.1",
         "functional-red-black-tree": "^1.0.1",
         "regexpp": "^3.0.0",
@@ -183,55 +183,55 @@
       }
     },
     "@typescript-eslint/experimental-utils": {
-      "version": "4.11.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.11.1.tgz",
-      "integrity": "sha512-mAlWowT4A6h0TC9F+J5pdbEhjNiEMO+kqPKQ4sc3fVieKL71dEqfkKgtcFVSX3cjSBwYwhImaQ/mXQF0oaI38g==",
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.12.0.tgz",
+      "integrity": "sha512-MpXZXUAvHt99c9ScXijx7i061o5HEjXltO+sbYfZAAHxv3XankQkPaNi5myy0Yh0Tyea3Hdq1pi7Vsh0GJb0fA==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.3",
-        "@typescript-eslint/scope-manager": "4.11.1",
-        "@typescript-eslint/types": "4.11.1",
-        "@typescript-eslint/typescript-estree": "4.11.1",
+        "@typescript-eslint/scope-manager": "4.12.0",
+        "@typescript-eslint/types": "4.12.0",
+        "@typescript-eslint/typescript-estree": "4.12.0",
         "eslint-scope": "^5.0.0",
         "eslint-utils": "^2.0.0"
       }
     },
     "@typescript-eslint/parser": {
-      "version": "4.11.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.11.1.tgz",
-      "integrity": "sha512-BJ3jwPQu1jeynJ5BrjLuGfK/UJu6uwHxJ/di7sanqmUmxzmyIcd3vz58PMR7wpi8k3iWq2Q11KMYgZbUpRoIPw==",
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.12.0.tgz",
+      "integrity": "sha512-9XxVADAo9vlfjfoxnjboBTxYOiNY93/QuvcPgsiKvHxW6tOZx1W4TvkIQ2jB3k5M0pbFP5FlXihLK49TjZXhuQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "4.11.1",
-        "@typescript-eslint/types": "4.11.1",
-        "@typescript-eslint/typescript-estree": "4.11.1",
+        "@typescript-eslint/scope-manager": "4.12.0",
+        "@typescript-eslint/types": "4.12.0",
+        "@typescript-eslint/typescript-estree": "4.12.0",
         "debug": "^4.1.1"
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "4.11.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.11.1.tgz",
-      "integrity": "sha512-Al2P394dx+kXCl61fhrrZ1FTI7qsRDIUiVSuN6rTwss6lUn8uVO2+nnF4AvO0ug8vMsy3ShkbxLu/uWZdTtJMQ==",
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.12.0.tgz",
+      "integrity": "sha512-QVf9oCSVLte/8jvOsxmgBdOaoe2J0wtEmBr13Yz0rkBNkl5D8bfnf6G4Vhox9qqMIoG7QQoVwd2eG9DM/ge4Qg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.11.1",
-        "@typescript-eslint/visitor-keys": "4.11.1"
+        "@typescript-eslint/types": "4.12.0",
+        "@typescript-eslint/visitor-keys": "4.12.0"
       }
     },
     "@typescript-eslint/types": {
-      "version": "4.11.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.11.1.tgz",
-      "integrity": "sha512-5kvd38wZpqGY4yP/6W3qhYX6Hz0NwUbijVsX2rxczpY6OXaMxh0+5E5uLJKVFwaBM7PJe1wnMym85NfKYIh6CA==",
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.12.0.tgz",
+      "integrity": "sha512-N2RhGeheVLGtyy+CxRmxdsniB7sMSCfsnbh8K/+RUIXYYq3Ub5+sukRCjVE80QerrUBvuEvs4fDhz5AW/pcL6g==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "4.11.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.11.1.tgz",
-      "integrity": "sha512-tC7MKZIMRTYxQhrVAFoJq/DlRwv1bnqA4/S2r3+HuHibqvbrPcyf858lNzU7bFmy4mLeIHFYr34ar/1KumwyRw==",
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.12.0.tgz",
+      "integrity": "sha512-gZkFcmmp/CnzqD2RKMich2/FjBTsYopjiwJCroxqHZIY11IIoN0l5lKqcgoAPKHt33H2mAkSfvzj8i44Jm7F4w==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.11.1",
-        "@typescript-eslint/visitor-keys": "4.11.1",
+        "@typescript-eslint/types": "4.12.0",
+        "@typescript-eslint/visitor-keys": "4.12.0",
         "debug": "^4.1.1",
         "globby": "^11.0.1",
         "is-glob": "^4.0.1",
@@ -241,12 +241,12 @@
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "4.11.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.11.1.tgz",
-      "integrity": "sha512-IrlBhD9bm4bdYcS8xpWarazkKXlE7iYb1HzRuyBP114mIaj5DJPo11Us1HgH60dTt41TCZXMaTCAW+OILIYPOg==",
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.12.0.tgz",
+      "integrity": "sha512-hVpsLARbDh4B9TKYz5cLbcdMIOAoBYgFPCSP9FFS/liSF+b33gVNq8JHY3QGhHNVz85hObvL7BEYLlgx553WCw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.11.1",
+        "@typescript-eslint/types": "4.12.0",
         "eslint-visitor-keys": "^2.0.0"
       }
     },
@@ -3281,9 +3281,9 @@
       "dev": true
     },
     "tsutils": {
-      "version": "3.17.1",
-      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.17.1.tgz",
-      "integrity": "sha512-kzeQ5B8H3w60nFY2g8cJIuH7JDpsALXySGtwGJ0p2LSjLgay3NdIpqq5SoOBe46bKDW2iq25irHCr8wjomUS2g==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.18.0.tgz",
+      "integrity": "sha512-D9Tu8nE3E7D1Bsf/V29oMHceMf+gnVO+pDguk/A5YRo1cLpkiQ48ZnbbS57pvvHeY+OIeNQx1vf4ASPlEtRpcA==",
       "dev": true,
       "requires": {
         "tslib": "^1.8.1"
@@ -3320,9 +3320,9 @@
       "dev": true
     },
     "typedoc": {
-      "version": "0.20.10",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.20.10.tgz",
-      "integrity": "sha512-1Bqbmf/1pwRiUkd1j1tvL7GIlBOFANFcjC+W5cZ02R0CKgUN+fIIl2Z2OhuaM7MVytKq6snF1KYVIwBvplO37g==",
+      "version": "0.20.12",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.20.12.tgz",
+      "integrity": "sha512-Cdg6tLicmhomai+GkVOLy1spmiZ8iAC4lrkU6oylK3KHNex9TrJjl++B2iCQ7eC5uiiv3MBfv4t6WzQ/M6jLTg==",
       "dev": true,
       "requires": {
         "colors": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -49,11 +49,11 @@
   "devDependencies": {
     "@types/chai": "^4.2.14",
     "@types/mocha": "^8.2.0",
-    "@types/node": "^14.14.16",
-    "@typescript-eslint/eslint-plugin": "^4.11.1",
-    "@typescript-eslint/parser": "^4.11.1",
+    "@types/node": "^14.14.20",
+    "@typescript-eslint/eslint-plugin": "^4.12.0",
+    "@typescript-eslint/parser": "^4.12.0",
     "chai": "^4.2.0",
-    "eslint": "^7.16.0",
+    "eslint": "^7.17.0",
     "eslint-config-standard": "^16.0.2",
     "eslint-config-standard-with-typescript": "^19.0.1",
     "eslint-import-resolver-node": "^0.3.4",
@@ -64,7 +64,7 @@
     "eslint-plugin-tsdoc": "^0.2.10",
     "husky": "^4.3.6",
     "mocha": "^8.2.1",
-    "typedoc": "^0.20.4",
+    "typedoc": "^0.20.12",
     "typescript": "^4.1.3"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "k-value",
   "description": "Node.js Map-like API based key-value storage with multiple persistent backend adapters.",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "license": "MIT",
   "author": "Samuel J Voeller <samuel.voeller@amethyst.live> (https://chat.amethyst.live/)",
   "contributors": [],
@@ -36,9 +36,8 @@
     "stage:build": "npx tsc --build",
     "stage:tests": "mocha './tests/**/*.js'",
     "project:build": "npm run stage:eslint && npm run stage:build && npm run stage:tests",
-    "project:upgrade": "npx npm-check-updates -u --target latest && wget https://www.toptal.com/developers/gitignore/api/node,yarn,webstorm+all,visualstudiocode,vscode -O ./.gitignore",
-    "project:generate-docs": "npx typedoc --out ./docs/ ./lib/",
-    "prepack": "npm run project:build"
+    "project:upgrade": "npx npm-check-updates -u --target latest && wget https://www.toptal.com/developers/gitignore/api/node,yarn,webstorm+all,visualstudiocode,vscode -O ./.gitignore && cat ./custom.gitignore >> .gitignore",
+    "project:generate-docs": "typedoc --out ./docs/ ./lib/"
   },
   "husky": {
     "hooks": {

--- a/tests/memory.test.js
+++ b/tests/memory.test.js
@@ -18,14 +18,25 @@ describe('Adapter - Memory', function () {
     await kv.set('delete-test', true)
     await kv.set('expire-test', true, { lifetime: 1 })
     await kv.set('has-test', true)
+    await kv.set('multi-test', { v: true })
     await kv.set('write-test', complex)
   })
-  it('should-read-data', async function () {
+  it('should-read-data-and-default', async function () {
     const kvr = await kv.get('write-test')
     expect(kvr.buffer.toString('base64')).to.equal(complex.buffer.toString('base64'))
     expect(kvr.date.getUTCMilliseconds()).to.equal(complex.date.getUTCMilliseconds())
     expect(kvr.map).to.deep.equal(complex.map)
     expect(kvr.set).to.deep.equal(complex.set)
+    expect((await kv.get('obviously-unknown-key-here', { default: { x: true } })).x).to.equal(true)
+  })
+  it('should-multi-read-data-and-default', async function () {
+    const kvr = await kv.get(['delete-test', 'has-test', 'multi-test', 'unknown-key'], { default: { x: true } })
+    expect(kvr).to.have.deep.members([
+      { key: 'delete-test', value: true },
+      { key: 'has-test', value: true },
+      { key: 'multi-test', value: { v: true } },
+      { key: 'unknown-key', value: { x: true } }
+    ])
   })
   it('should-delete-data', async function () {
     expect(await kv.delete('delete-test')).to.equal(true)
@@ -35,7 +46,6 @@ describe('Adapter - Memory', function () {
   it('should-resolve-key-existence-and-default', async function () {
     expect(await kv.has('has-test')).to.equal(true)
     expect(await kv.has('obviously-unknown-key-here')).to.equal(false)
-    expect((await kv.get('obviously-unknown-key-here', { default: { x: true } })).x).to.equal(true)
   })
   it('should-index-keys', async function () {
     const keys = await kv.keys()

--- a/tests/memory.test.js
+++ b/tests/memory.test.js
@@ -32,9 +32,10 @@ describe('Adapter - Memory', function () {
     expect(await kv.keys()).to.not.include('delete-test')
     expect(await kv.get('expire-test')).to.equal(undefined)
   })
-  it('should-resolve-key-existence', async function () {
+  it('should-resolve-key-existence-and-default', async function () {
     expect(await kv.has('has-test')).to.equal(true)
     expect(await kv.has('obviously-unknown-key-here')).to.equal(false)
+    expect((await kv.get('obviously-unknown-key-here', { default: { x: true } })).x).to.equal(true)
   })
   it('should-index-keys', async function () {
     const keys = await kv.keys()

--- a/tests/mysql.test.js
+++ b/tests/mysql.test.js
@@ -49,9 +49,10 @@ describe('Adapter - MySQLAdapter', function () {
     expect(await kv.keys()).to.not.include('delete-test')
     expect(await kv.get('expire-test')).to.equal(undefined)
   })
-  it('should-resolve-key-existence', async function () {
+  it('should-resolve-key-existence-and-default', async function () {
     expect(await kv.has('has-test')).to.equal(true)
     expect(await kv.has('obviously-unknown-key-here')).to.equal(false)
+    expect((await kv.get('obviously-unknown-key-here', { default: { x: true } })).x).to.equal(true)
   })
   it('should-index-keys', async function () {
     const keys = await kv.keys()

--- a/tests/sqlite.test.js
+++ b/tests/sqlite.test.js
@@ -42,9 +42,10 @@ describe('Adapter - SQLite', function () {
     expect(await kv.keys()).to.not.include('delete-test')
     expect(await kv.get('expire-test')).to.equal(undefined)
   })
-  it('should-resolve-key-existence', async function () {
+  it('should-resolve-key-existence-and-default', async function () {
     expect(await kv.has('has-test')).to.equal(true)
     expect(await kv.has('obviously-unknown-key-here')).to.equal(false)
+    expect((await kv.get('obviously-unknown-key-here', { default: { x: true } })).x).to.equal(true)
   })
   it('should-index-keys', async function () {
     const keys = await kv.keys()

--- a/tests/sqlite.test.js
+++ b/tests/sqlite.test.js
@@ -28,14 +28,25 @@ describe('Adapter - SQLite', function () {
     await kv.set('delete-test', true)
     await kv.set('expire-test', true, { lifetime: 1 })
     await kv.set('has-test', true)
+    await kv.set('multi-test', { v: true })
     await kv.set('write-test', complex)
   })
-  it('should-read-data', async function () {
+  it('should-read-data-and-default', async function () {
     const kvr = await kv.get('write-test')
     expect(kvr.buffer.toString('base64')).to.equal(complex.buffer.toString('base64'))
     expect(kvr.date.getUTCMilliseconds()).to.equal(complex.date.getUTCMilliseconds())
     expect(kvr.map).to.deep.equal(complex.map)
     expect(kvr.set).to.deep.equal(complex.set)
+    expect((await kv.get('obviously-unknown-key-here', { default: { x: true } })).x).to.equal(true)
+  })
+  it('should-multi-read-data-and-default', async function () {
+    const kvr = await kv.get(['delete-test', 'has-test', 'multi-test', 'unknown-key'], { default: { x: true } })
+    expect(kvr).to.have.deep.members([
+      { key: 'delete-test', value: true },
+      { key: 'has-test', value: true },
+      { key: 'multi-test', value: { v: true } },
+      { key: 'unknown-key', value: { x: true } }
+    ])
   })
   it('should-delete-data', async function () {
     expect(await kv.delete('delete-test')).to.equal(true)


### PR DESCRIPTION
#### Checklist for Integrity
<!-- Please remove any items that do not apply. For completed items, change [] to [x]. -->

- [x] `npm run project:build` passes without issues. This will be automatically executed with a Matrix on GitHub Workflow.
- [x] Tests have been updated or added to reflect your changes if you modified existing adapters or added new adapters.
- [x] Documentation on all classes, functions, and properties have been included in added or modified source code.
- [x] All commit message(es) follow the syntax of [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0-beta.2/#summary).

#### Affected Core Services
Adapter#get() functionality on a global scope. Affects all current adapters.

#### Description of the Changes
Allows specifying a default value on the `Adapter#get()` action.
```js
adapter.get('non-existant-key', { default: { x: true } })
```